### PR TITLE
Fixed the plugin.

### DIFF
--- a/discord.py
+++ b/discord.py
@@ -170,8 +170,12 @@ async def start(rec_tries=0):
 
 
 async def open_friends_page(session: CdpSession):
+    # Simulate the user clicking on the "Home" button.
     await session.execute(runtime.evaluate("""document.querySelector('a[aria-label="Home"][href]').click()"""))
+    # Simulate the user clicking on the "Friends" button.
     await session.execute(runtime.evaluate("""document.querySelector("a[href='/channels/@me']").click()"""))
+    # Navigates to the PersonWaving icon, goes up two elements, and then selects the second button (All) to show all of
+    # the user's friends.
     await session.execute(runtime.evaluate(
         """document.querySelectorAll("svg[name='PersonWaving']")[1].parentElement.parentElement.querySelectorAll
         ("div[role='button']")[2].click()"""))

--- a/galaxy/api/consts.py
+++ b/galaxy/api/consts.py
@@ -90,6 +90,7 @@ class Platform(Enum):
     Playfire = "playfire"
     Oculus = "oculus"
     Test = "test"
+    Rockstar = "rockstar"
 
 
 class Feature(Enum):
@@ -111,6 +112,8 @@ class Feature(Enum):
     ShutdownPlatformClient = "ShutdownPlatformClient"
     LaunchPlatformClient = "LaunchPlatformClient"
     ImportGameLibrarySettings = "ImportGameLibrarySettings"
+    ImportOSCompatibility = "ImportOSCompatibility"
+    ImportUserPresence = "ImportUserPresence"
 
 
 class LicenseType(Enum):
@@ -129,3 +132,20 @@ class LocalGameState(Flag):
     None_ = 0
     Installed = 1
     Running = 2
+
+
+class OSCompatibility(Flag):
+    """Possible game OS compatibility.
+    Use "bitwise or" to express multiple OSs compatibility, e.g. ``os=OSCompatibility.Windows|OSCompatibility.MacOS``
+    """
+    Windows = 0b001
+    MacOS   = 0b010
+    Linux   = 0b100
+
+
+class PresenceState(Enum):
+    """"Possible states of a user."""
+    Unknown = "unknown"
+    Online = "online"
+    Offline = "offline"
+    Away = "away"

--- a/galaxy/api/plugin.py
+++ b/galaxy/api/plugin.py
@@ -7,11 +7,14 @@ import sys
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 
-from galaxy.api.consts import Feature
+from galaxy.api.consts import Feature, OSCompatibility
 from galaxy.api.errors import ImportInProgress, UnknownError
 from galaxy.api.jsonrpc import ApplicationError, NotificationClient, Server
-from galaxy.api.types import Achievement, Authentication, FriendInfo, Game, GameTime, LocalGame, NextStep, GameLibrarySettings
+from galaxy.api.types import (
+    Achievement, Authentication, FriendInfo, Game, GameLibrarySettings, GameTime, LocalGame, NextStep, UserPresence
+)
 from galaxy.task_manager import TaskManager
+
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):  # pylint: disable=method-hidden
@@ -47,6 +50,8 @@ class Plugin:
         self._achievements_import_in_progress = False
         self._game_times_import_in_progress = False
         self._game_library_settings_import_in_progress = False
+        self._os_compatibility_import_in_progress = False
+        self._user_presence_import_in_progress = False
 
         self._persistent_cache = dict()
 
@@ -113,6 +118,12 @@ class Plugin:
         self._register_method("start_game_library_settings_import", self._start_game_library_settings_import)
         self._detect_feature(Feature.ImportGameLibrarySettings, ["get_game_library_settings"])
 
+        self._register_method("start_os_compatibility_import", self._start_os_compatibility_import)
+        self._detect_feature(Feature.ImportOSCompatibility, ["get_os_compatibility"])
+
+        self._register_method("start_user_presence_import", self._start_user_presence_import)
+        self._detect_feature(Feature.ImportUserPresence, ["get_user_presence"])
+
     async def __aenter__(self):
         return self
 
@@ -173,11 +184,13 @@ class Plugin:
     def _wrap_external_method(self, handler, name: str):
         async def wrapper(*args, **kwargs):
             return await self._external_task_manager.create_task(handler(*args, **kwargs), name, False)
+
         return wrapper
 
     async def run(self):
         """Plugin's main coroutine."""
         await self._server.run()
+        logging.debug("Plugin run loop finished")
 
     def close(self) -> None:
         if not self._active:
@@ -190,10 +203,12 @@ class Plugin:
         self._active = False
 
     async def wait_closed(self) -> None:
+        logging.debug("Waiting for plugin to close")
         await self._external_task_manager.wait()
         await self._internal_task_manager.wait()
         await self._server.wait_closed()
         await self._notification_client.close()
+        logging.debug("Plugin closed")
 
     def create_task(self, coro, description):
         """Wrapper around asyncio.create_task - takes care of canceling tasks on shutdown"""
@@ -256,7 +271,7 @@ class Plugin:
 
         """
         # temporary solution for persistent_cache vs credentials issue
-        self.persistent_cache['credentials'] = credentials  # type: ignore
+        self.persistent_cache["credentials"] = credentials  # type: ignore
 
         self._notification_client.notify("store_credentials", credentials, sensitive_params=True)
 
@@ -419,6 +434,48 @@ class Plugin:
 
     def _game_library_settings_import_finished(self) -> None:
         self._notification_client.notify("game_library_settings_import_finished", None)
+
+    def _os_compatibility_import_success(self, game_id: str, os_compatibility: Optional[OSCompatibility]) -> None:
+        self._notification_client.notify(
+            "os_compatibility_import_success",
+            {
+                "game_id": game_id,
+                "os_compatibility": os_compatibility
+            }
+        )
+
+    def _os_compatibility_import_failure(self, game_id: str, error: ApplicationError) -> None:
+        self._notification_client.notify(
+            "os_compatibility_import_failure",
+            {
+                "game_id": game_id,
+                "error": error.json()
+            }
+        )
+
+    def _os_compatibility_import_finished(self) -> None:
+        self._notification_client.notify("os_compatibility_import_finished", None)
+
+    def _user_presence_import_success(self, user_id: str, user_presence: UserPresence) -> None:
+        self._notification_client.notify(
+            "user_presence_import_success",
+            {
+                "user_id": user_id,
+                "presence": user_presence
+            }
+        )
+
+    def _user_presence_import_failure(self, user_id: str, error: ApplicationError) -> None:
+        self._notification_client.notify(
+            "user_presence_import_failure",
+            {
+                "user_id": user_id,
+                "error": error.json()
+            }
+        )
+
+    def _user_presence_import_finished(self) -> None:
+        self._notification_client.notify("user_presence_import_finished", None)
 
     def lost_authentication(self) -> None:
         """Notify the client that integration has lost authentication for the
@@ -805,7 +862,7 @@ class Plugin:
         This allows for optimizations like batch requests to platform API.
         Default implementation returns None.
 
-        :param game_ids: the ids of the games for which game time are imported
+        :param game_ids: the ids of the games for which game library settings are imported
         :return: context
         """
         return None
@@ -815,16 +872,129 @@ class Plugin:
         identified by the provided game_id.
         This method is called by import task initialized by GOG Galaxy Client.
 
-        :param game_id: the id of the game for which the game time is returned
+        :param game_id: the id of the game for which the game library settings are imported
         :param context: the value returned from :meth:`prepare_game_library_settings_context`
         :return: GameLibrarySettings object
         """
         raise NotImplementedError()
 
     def game_library_settings_import_complete(self) -> None:
-        """Override this method to handle operations after game times import is finished
+        """Override this method to handle operations after game library settings import is finished
         (like updating cache).
         """
+
+    async def _start_os_compatibility_import(self, game_ids: List[str]) -> None:
+        if self._os_compatibility_import_in_progress:
+            raise ImportInProgress()
+
+        context = await self.prepare_os_compatibility_context(game_ids)
+
+        async def import_os_compatibility(game_id, context_):
+            try:
+                os_compatibility = await self.get_os_compatibility(game_id, context_)
+                self._os_compatibility_import_success(game_id, os_compatibility)
+            except ApplicationError as error:
+                self._os_compatibility_import_failure(game_id, error)
+            except Exception:
+                logging.exception("Unexpected exception raised in import_os_compatibility")
+                self._os_compatibility_import_failure(game_id, UnknownError())
+
+        async def import_os_compatibility_set(game_ids_, context_):
+            try:
+                await asyncio.gather(*[
+                    import_os_compatibility(game_id, context_) for game_id in game_ids_
+                ])
+            finally:
+                self._os_compatibility_import_finished()
+                self._os_compatibility_import_in_progress = False
+                self.os_compatibility_import_complete()
+
+        self._external_task_manager.create_task(
+            import_os_compatibility_set(game_ids, context),
+            "game OS compatibility import",
+            handle_exceptions=False
+        )
+        self._os_compatibility_import_in_progress = True
+
+    async def prepare_os_compatibility_context(self, game_ids: List[str]) -> Any:
+        """Override this method to prepare context for get_os_compatibility.
+        This allows for optimizations like batch requests to platform API.
+        Default implementation returns None.
+
+        :param game_ids: the ids of the games for which game os compatibility is imported
+        :return: context
+        """
+        return None
+
+    async def get_os_compatibility(self, game_id: str, context: Any) -> Optional[OSCompatibility]:
+        """Override this method to return the OS compatibility for the game with the provided game_id.
+        This method is called by import task initialized by GOG Galaxy Client.
+
+        :param game_id: the id of the game for which the game os compatibility is imported
+        :param context: the value returned from :meth:`prepare_os_compatibility_context`
+        :return: OSCompatibility flags indicating compatible OSs, or None if compatibility is not know
+        """
+        raise NotImplementedError()
+
+    def os_compatibility_import_complete(self) -> None:
+        """Override this method to handle operations after OS compatibility import is finished (like updating cache)."""
+
+    async def _start_user_presence_import(self, user_ids: List[str]) -> None:
+        if self._user_presence_import_in_progress:
+            raise ImportInProgress()
+
+        context = await self.prepare_user_presence_context(user_ids)
+
+        async def import_user_presence(user_id, context_) -> None:
+            try:
+                self._user_presence_import_success(user_id, await self.get_user_presence(user_id, context_))
+            except ApplicationError as error:
+                self._user_presence_import_failure(user_id, error)
+            except Exception:
+                logging.exception("Unexpected exception raised in import_user_presence")
+                self._user_presence_import_failure(user_id, UnknownError())
+
+        async def import_user_presence_set(user_ids_, context_) -> None:
+            try:
+                await asyncio.gather(*[
+                    import_user_presence(user_id, context_)
+                    for user_id in user_ids_
+                ])
+            finally:
+                self._user_presence_import_finished()
+                self._user_presence_import_in_progress = False
+                self.user_presence_import_complete()
+
+        self._external_task_manager.create_task(
+            import_user_presence_set(user_ids, context),
+            "user presence import",
+            handle_exceptions=False
+        )
+        self._user_presence_import_in_progress = True
+
+    async def prepare_user_presence_context(self, user_ids: List[str]) -> Any:
+        """Override this method to prepare context for get_user_presence.
+        This allows for optimizations like batch requests to platform API.
+        Default implementation returns None.
+
+        :param user_ids: the ids of the users for whom presence information is imported
+        :return: context
+        """
+        return None
+
+    async def get_user_presence(self, user_id: str, context: Any) -> UserPresence:
+        """Override this method to return presence information for the user with the provided user_id.
+        This method is called by import task initialized by GOG Galaxy Client.
+
+        :param user_id: the id of the user for whom presence information is imported
+        :param context: the value returned from :meth:`prepare_user_presence_context`
+        :return: UserPresence presence information of the provided user
+        """
+        raise NotImplementedError()
+
+    def user_presence_import_complete(self) -> None:
+        """Override this method to handle operations after presence import is finished (like updating cache)."""
+
 
 def create_and_run_plugin(plugin_class, argv):
     """Call this method as an entry point for the implemented integration.

--- a/galaxy/api/types.py
+++ b/galaxy/api/types.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
-from galaxy.api.consts import LicenseType, LocalGameState
+from galaxy.api.consts import LicenseType, LocalGameState, PresenceState
+
 
 @dataclass
-class Authentication():
+class Authentication:
     """Return this from :meth:`.authenticate` or :meth:`.pass_login_credentials`
     to inform the client that authentication has successfully finished.
 
@@ -14,8 +15,9 @@ class Authentication():
     user_id: str
     user_name: str
 
+
 @dataclass
-class Cookie():
+class Cookie:
     """Cookie
 
     :param name: name of the cookie
@@ -28,8 +30,9 @@ class Cookie():
     domain: Optional[str] = None
     path: Optional[str] = None
 
+
 @dataclass
-class NextStep():
+class NextStep:
     """Return this from :meth:`.authenticate` or :meth:`.pass_login_credentials` to open client built-in browser with given url.
     For example:
 
@@ -67,8 +70,9 @@ class NextStep():
     cookies: Optional[List[Cookie]] = None
     js: Optional[Dict[str, List[str]]] = None
 
+
 @dataclass
-class LicenseInfo():
+class LicenseInfo:
     """Information about the license of related product.
 
     :param license_type: type of license
@@ -77,8 +81,9 @@ class LicenseInfo():
     license_type: LicenseType
     owner: Optional[str] = None
 
+
 @dataclass
-class Dlc():
+class Dlc:
     """Downloadable content object.
 
     :param dlc_id: id of the dlc
@@ -89,8 +94,9 @@ class Dlc():
     dlc_title: str
     license_info: LicenseInfo
 
+
 @dataclass
-class Game():
+class Game:
     """Game object.
 
     :param game_id: unique identifier of the game, this will be passed as parameter for methods such as launch_game
@@ -103,8 +109,9 @@ class Game():
     dlcs: Optional[List[Dlc]]
     license_info: LicenseInfo
 
+
 @dataclass
-class Achievement():
+class Achievement:
     """Achievement, has to be initialized with either id or name.
 
     :param unlock_time: unlock time of the achievement
@@ -119,8 +126,9 @@ class Achievement():
         assert self.achievement_id or self.achievement_name, \
             "One of achievement_id or achievement_name is required"
 
+
 @dataclass
-class LocalGame():
+class LocalGame:
     """Game locally present on the authenticated user's computer.
 
     :param game_id: id of the game
@@ -129,8 +137,9 @@ class LocalGame():
     game_id: str
     local_game_state: LocalGameState
 
+
 @dataclass
-class FriendInfo():
+class FriendInfo:
     """Information about a friend of the currently authenticated user.
 
     :param user_id: id of the user
@@ -139,8 +148,9 @@ class FriendInfo():
     user_id: str
     user_name: str
 
+
 @dataclass
-class GameTime():
+class GameTime:
     """Game time of a game, defines the total time spent in the game
     and the last time the game was played.
 
@@ -152,8 +162,9 @@ class GameTime():
     time_played: Optional[int]
     last_played_time: Optional[int]
 
+
 @dataclass
-class GameLibrarySettings():
+class GameLibrarySettings:
     """Library settings of a game, defines assigned tags and visibility flag.
 
     :param game_id: id of the related game
@@ -163,3 +174,18 @@ class GameLibrarySettings():
     game_id: str
     tags: Optional[List[str]]
     hidden: Optional[bool]
+
+
+@dataclass
+class UserPresence:
+    """Presence information of a user.
+
+    :param presence_state: the state of the user
+    :param game_id: id of the game a user is currently in
+    :param game_title: name of the game a user is currently in
+    :param presence_status: detailed user's presence description
+    """
+    presence_state: PresenceState
+    game_id: Optional[str] = None
+    game_title: Optional[str] = None
+    presence_status: Optional[str] = None

--- a/galaxy/http.py
+++ b/galaxy/http.py
@@ -78,7 +78,8 @@ def create_tcp_connector(*args, **kwargs) -> aiohttp.TCPConnector:
     ssl_context.load_verify_locations(certifi.where())
     kwargs.setdefault("ssl", ssl_context)
     kwargs.setdefault("limit", DEFAULT_LIMIT)
-    return aiohttp.TCPConnector(*args, **kwargs)  # type: ignore due to https://github.com/python/mypy/issues/4001
+    # due to https://github.com/python/mypy/issues/4001
+    return aiohttp.TCPConnector(*args, **kwargs)  # type: ignore
 
 
 def create_client_session(*args, **kwargs) -> aiohttp.ClientSession:
@@ -103,7 +104,8 @@ def create_client_session(*args, **kwargs) -> aiohttp.ClientSession:
     kwargs.setdefault("connector", create_tcp_connector())
     kwargs.setdefault("timeout", aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT))
     kwargs.setdefault("raise_for_status", True)
-    return aiohttp.ClientSession(*args, **kwargs)  # type: ignore due to https://github.com/python/mypy/issues/4001
+    # due to https://github.com/python/mypy/issues/4001
+    return aiohttp.ClientSession(*args, **kwargs)  # type: ignore
 
 
 @contextmanager

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Discord Integration",
     "platform": "discord",
     "guid": "ce69028e-a7e4-462a-96d8-468259c298e2",
-    "version": "0.1",
+    "version": "0.1.1",
     "description": "Discord Integration",
     "author": "Da-ve",
     "email": "david.mysi@gmail.com",


### PR DESCRIPTION
I went ahead and fixed the Discord plugin for you. The version has been incremented to v0.1.1 as a result, although you may change this to suit you. In addition, here is a list of additional notes which you should know:

* **I made sure to follow a similar approach to your original implementation for the plugin, so that this new version still "abides by" Discord's ToS. This restriction admittedly makes it difficult to gather more information regarding the user's account, but users _should_ be safe when using it.**
* The method for scraping Discord has been altered drastically, and all dependencies on ```trio``` have been removed. However, the plugin now depends on the ```websocket-client``` module. All necessary modules are included in the release below.
* The current structure of the plugin is not very organized. If I were you, I would look into making the design object-oriented to improve clarity. There would not be many separate .py files for this plugin, since it is not as complicated as most others, but every bit of organization and flexibility helps.
* The current method for re-authenticating the user is not sufficient. Here is the current implementation:
```python
async def ensure_discord_scraped(self):
    if not self.user_email:
        await self.scrape_discord()
```
The main reason as to why this implementation is flawed is that it does not account for any changes to the user's account. For instance, suppose that the user adds a Discord friend after authenticating with the plugin. This new friend would not appear on Galaxy 2.0, since the plugin would determine that it does not need to re-authenticate the user because self.user_email is defined. I offered some possible solutions to this in the comments below this method (check discord.py).
* This version of the plugin is by no means a finished version, and there are still improvements that could yet be made. For instance, try to detect the user's Discord installation path so that they do not need to launch Discord before authenticating with your plugin. I am not sure of a Mac solution, but a great idea for Windows would be to make use of the Windows Registry to check uninstall registry keys. If you ever have any questions regarding how to make certain improvements, take a look at other plugins (such as my Rockstar plugin at https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar) or feel free to ask me or other developers. This community has been very helpful to me while I have 
been developing my own plugin!

This is all that I can think of for now. I will attach a working build to the bottom of this post (Discord.zip), which you can publish as a release for v0.1.1 (or whatever you decide to call it). When you release this new version, make sure to notify @Slashbunny for their GOG Galaxy Plugin Downloader, located at https://github.com/Slashbunny/gog-galaxy-plugin-downloader. Keep up the great work, and sorry for the long wall of text!

**[Discord.zip](https://github.com/Ertego/gog-galaxy-discord/files/3844592/Discord.zip)**
